### PR TITLE
add setLoginCookie

### DIFF
--- a/lib/better-pastebin.js
+++ b/lib/better-pastebin.js
@@ -24,6 +24,10 @@ pbapi = {
         pbapi.devkey = devkey;
     },
 
+    setLoginCookie: function(cookie) {
+        jar.setCookie("pastebin_user="+cookie, "http://pastebin.com/");
+    },
+
     login: function(username, password, cb) {
         var both = 0;
 

--- a/lib/better-pastebin.js
+++ b/lib/better-pastebin.js
@@ -25,7 +25,7 @@ pbapi = {
     },
 
     setLoginCookie: function(cookie) {
-        jar.setCookie("pastebin_user="+cookie, "http://pastebin.com/");
+        jar.setCookie("pastebin_user=" + cookie, "http://pastebin.com/");
     },
 
     login: function(username, password, cb) {


### PR DESCRIPTION
setLoginCookie allow to specify the login cookie, instead of using ``paste.login``, because when you use ``paste.login`` you get 'disconnected' from pastebin website.

Usage:
![](http://i.imgur.com/UZnCRp9.png)

English isn’t my first language, so excuse any mistakes